### PR TITLE
Perlmutter setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 Legacy Surveys DR9 Photometric Catalogs for DESI Productions Fuji and Guadalupe
 ===============================================================================
 
-DESI Value-Added Catalogs  
-Fuji (Early Data Release)  
-Guadalupe (Data Release 1 Supplement)  
+DESI Value-Added Catalogs
+Fuji (Early Data Release)
+Guadalupe (Data Release 1 Supplement)
 
-**Version: 1.0**  
+**Version: 1.0**
 
 Description
 -----------
@@ -224,7 +224,7 @@ below:
 | potential-targets/targetphot-potential-main-guadalupe.fits | 17.1 GB | 16,603,258 | Main Survey |
 | potential-targets/targetphot-potential-guadalupe.fits | 17.2 GB | 16,683,440 | Stack of the preceding 2 catalogs. |
 
-##### *tractorphot* 
+##### *tractorphot*
 
 | Data Release | Relative Location of *tractorphot* Files | Number of Files | Total Data Volume | Total Number of Objects |
 |--------------|------------------------------------------|:---------------:|:-----------------:|:-----------------------:|
@@ -251,13 +251,18 @@ git clone https://github.com/moustakas/desi-photometry.git
 cd desi-photometry && git checkout tags/v1.0 && cd ..
 ```
 
-2. Next, gather targeting and Tractor photometry for *observed* targets:
+2. Next, set up the `perlmutter` interactive node to run the code:
+```bash
+salloc -N 1 -C cpu -A desi -t 01:00:00 --qos interactive -L SCRATCH,cfs
+```
+
+3. Next, gather targeting and Tractor photometry for *observed* targets:
 ```bash
 time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji \
   -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot
 ```
 
-3. Finally gather targeting and Tractor photometry for *potential* targets:
+4. Finally gather targeting and Tractor photometry for *potential* targets (you may want to start another interactive node):
 ```bash
 time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji \
   -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot --potential

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ cd desi-photometry && git checkout tags/v1.0 && cd ..
 
 2. Next, set up the `cori` interactive node to run the code:
 ```bash
-salloc -N 1 -C knl -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
+salloc -N 1 -C haswell -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
 # equivalent on perlmutter
 salloc -N 1 -C cpu -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
 ```

--- a/README.md
+++ b/README.md
@@ -268,7 +268,12 @@ time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/s
   -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot --potential
 ```
 
-5. This is a test.
+Known Issues
+------------
+
+* For secondary targets in SV1, the targeting catalog filenames recorded in the
+  fiberassign header are inconsistent with the contents of the corresponding
+  fibermap catalog for a given TILEID.
 
 Contact & Contributors
 ----------------------

--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/s
   -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot --potential
 ```
 
+5. This is a test.
+
 Contact & Contributors
 ----------------------
 

--- a/README.md
+++ b/README.md
@@ -243,17 +243,16 @@ just for Fuji).
 ```bash
 source /global/common/software/desi/desi_environment.sh 22.2
 module unload desispec
-cd /path/to/desi/code
-git clone https://github.com/desihub/desispec.git
-cd desispec && git checkout tags/0.53.2 && cd ..
-export PYTHONPATH=/path/to/desi/code/desispec/py:${PYTHONPATH}
+module load desispec/0.53.2
 git clone https://github.com/moustakas/desi-photometry.git
 cd desi-photometry && git checkout tags/v1.0 && cd ..
 ```
 
-2. Next, set up the `perlmutter` interactive node to run the code:
+2. Next, set up the `cori` interactive node to run the code:
 ```bash
-salloc -N 1 -C cpu -A desi -t 01:00:00 --qos interactive -L SCRATCH,cfs
+salloc -N 1 -C knl -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
+# equivalent on perlmutter
+salloc -N 1 -C cpu -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
 ```
 
 3. Next, gather targeting and Tractor photometry for *observed* targets:


### PR DESCRIPTION
This PR adds the `salloc` commands for cori and perlmutter in the Reproducibility section.

Additional question from the Known Issues section:
```
* For secondary targets in SV1, the targeting catalog filenames recorded in the
  fiberassign header are inconsistent with the contents of the corresponding
  fibermap catalog for a given TILEID.
```
Isn't that fixed now, by the most recent major patch of the fiberassign files?