### PR TITLE
create v2.0 VACs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ as well as some additional details regarding the files in the following table:
 
 | Data Release | Relative Location of *tractorphot* Files | Number of Files | Total Data Volume | Total Number of Objects |
 |--------------|------------------------------------------|:---------------:|:-----------------:|:-----------------------:|
-| Fuji | observed-targets/tractorphot/tractorphot-nside4-hp[0-9][0-9][0-9]-fuji.fits | 71 | 3.86 GB | 1,957,908 |
+| Fuji | observed-targets/tractorphot/tractorphot-nside4-hp[0-9][0-9][0-9]-fuji.fits | 71 | 3.86 GB | 1,957,907 |
 | Guadalupe | observed-targets/tractorphot/tractorphot-nside4-hp[0-9][0-9][0-9]-guadalupe.fits | 43 | 5.14 GB | 2,603,942 |
 
 **Note:**
 
-* In Fuji, there are 1,979,269 unique observed targets (the 2,005,503 number
+* In Fuji, there are 1,979,269 unique observed targets (the 2,786,841 number
   tabulated above includes duplicate targets observed in different surveys), but
-  just 1,957,908 unique objects with LS/DR9 photometry; the "missing" 21,361
+  just 1,957,907 unique objects with LS/DR9 photometry; the "missing" 21,362
   objects have no LS/DR9 source within 1 arcsec of the targeted position and
   therefore do not exist in any of the Fuji *tractorphot* files.
 
@@ -228,7 +228,7 @@ below:
 
 | Data Release | Relative Location of *tractorphot* Files | Number of Files | Total Data Volume | Total Number of Objects |
 |--------------|------------------------------------------|:---------------:|:-----------------:|:-----------------------:|
-| Fuji | potential-targets/tractorphot/tractorphot-potential-nside4-hp[0-9][0-9][0-9]-fuji.fits | 71 | 11.9 GB | 6,031,273 |
+| Fuji | potential-targets/tractorphot/tractorphot-potential-nside4-hp[0-9][0-9][0-9]-fuji.fits | 71 | 11.9 GB | 6,031,271 |
 | Guadalupe | potential-targets/tractorphot/tractorphot-potential-nside4-hp[0-9][0-9][0-9]-guadalupe.fits | 43 | 31.1 GB | 15,758,409 |
 
 Reproducibility
@@ -250,7 +250,7 @@ cd desi-photometry && git checkout tags/v2.0 && cd ..
 
 2. Next, set up the `perlmutter` interactive node to run the code:
 ```bash
-salloc -N 1 -C cpu -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
+salloc -N 1 -C cpu -A desi -t 02:00:00 --qos interactive -L SCRATCH,cfs
 ```
 
 3. Next, gather targeting and Tractor photometry for *observed* targets:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ DESI Value-Added Catalogs
 Fuji (Early Data Release)
 Guadalupe (Data Release 1 Supplement)
 
-**Version: 1.0**
+**Version: 2.0**
 
 Description
 -----------
@@ -31,7 +31,7 @@ Getting Started Quickly
 -----------------------
 
 This [example
-notebook](https://github.com/moustakas/desi-photometry/blob/fujilupe-v1.0/example.ipynb)
+notebook](https://github.com/moustakas/desi-photometry/blob/main/example.ipynb)
 shows how to quickly grab targeting and Tractor photometry from the Fuji
 value-added catalog for a hypothetical set of observed targets. However, be sure
 to read the documentation below for all the details!
@@ -42,14 +42,14 @@ Content, Organization, & Data Model
 The LS/DR9 value-added catalogs (VACs) can be accessed at the following links:
 | Data Release | URL |
 |------------|-----|
-| Fuji (EDR) | [https://data.desi.lbl.gov/public/edr/vac/lsdr9-photometry/fuji/v1.0](https://data.desi.lbl.gov/public/edr/vac/lsdr9-photometry/fuji/v1.0) |
-| Guadalupe (DR1 supplement) | [https://data.desi.lbl.gov/public/dr1/vac/lsdr9-photometry/guadalupe/v1.0](https://data.desi.lbl.gov/public/dr1/vac/lsdr9-photometry/guadalupe/v1.0) |
+| Fuji (EDR) | [https://data.desi.lbl.gov/public/edr/vac/lsdr9-photometry/fuji/v2.0](https://data.desi.lbl.gov/public/edr/vac/lsdr9-photometry/fuji/v2.0) |
+| Guadalupe (DR1 supplement) | [https://data.desi.lbl.gov/public/dr1/vac/lsdr9-photometry/guadalupe/v2.0](https://data.desi.lbl.gov/public/dr1/vac/lsdr9-photometry/guadalupe/v2.0) |
 
 > **For DESI Collaborators:** At NERSC, the catalogs can also be accessed at the
     following top-level directories:
   ```
-  /global/cfs/cdirs/desi/public/edr/vac/lsdr9-photometry/fuji/v1.0
-  /global/cfs/cdirs/desi/public/dr1/vac/lsdr9-photometry/guadalupe/v1.0
+  /global/cfs/cdirs/desi/public/edr/vac/lsdr9-photometry/fuji/v2.0
+  /global/cfs/cdirs/desi/public/dr1/vac/lsdr9-photometry/guadalupe/v2.0
   ```
 
 The VAC contains two basic kinds of files: targeting (*targetphot*) catalogs,
@@ -241,38 +241,34 @@ just for Fuji).
 
 1. First, set up your software environment:
 ```bash
-source /global/common/software/desi/desi_environment.sh 22.2
+source /global/common/software/desi/desi_environment.sh 22.5
 module unload desispec
-module load desispec/0.53.2
+module load desispec/0.56.3
 git clone https://github.com/moustakas/desi-photometry.git
-cd desi-photometry && git checkout tags/v1.0 && cd ..
+cd desi-photometry && git checkout tags/v2.0 && cd ..
 ```
 
-2. Next, set up the `cori` interactive node to run the code:
+2. Next, set up the `perlmutter` interactive node to run the code:
 ```bash
-salloc -N 1 -C haswell -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
-# equivalent on perlmutter
 salloc -N 1 -C cpu -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
 ```
 
 3. Next, gather targeting and Tractor photometry for *observed* targets:
 ```bash
 time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji \
-  -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot
+  -o /path/to/output/fuji --specprod fuji --mp 128 --targetphot --tractorphot
 ```
 
 4. Finally gather targeting and Tractor photometry for *potential* targets (you may want to start another interactive node):
 ```bash
 time /path/to/desi/code/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji \
-  -o /path/to/output/fuji --specprod fuji --mp 32 --targetphot --tractorphot --potential
+  -o /path/to/output/fuji --specprod fuji --mp 128 --targetphot --tractorphot --potential
 ```
 
 Known Issues
 ------------
 
-* For secondary targets in SV1, the targeting catalog filenames recorded in the
-  fiberassign header are inconsistent with the contents of the corresponding
-  fibermap catalog for a given TILEID.
+None currently known.
 
 Contact & Contributors
 ----------------------
@@ -282,7 +278,7 @@ file a ticket at the [desi-photometry
 repository](https://github.com/moustakas/desi-photometry/issues) and/or contact
 [John Moustakas](jmoustakas@siena.edu) ([Siena College](https://siena.edu)).
 
-JM gratefully acknowledges funding support for this work from the
+John Moustakas gratefully acknowledges funding support for this work from the
 U.S. Department of Energy, Office of Science, Office of High Energy Physics
 under Award Number DE-SC0020086.
 

--- a/lsdr9-photometry
+++ b/lsdr9-photometry
@@ -207,7 +207,8 @@ def targetphot_one(input_cat, photocache=None, racolumn='TARGET_RA', deccolumn='
     assert(len(input_cat) == len(np.unique(input_cat['TARGETID'])))
 
     targetphot = gather_targetphot(input_cat, photocache=photocache,
-                                   racolumn=racolumn, deccolumn=deccolumn)
+                                   racolumn=racolumn, deccolumn=deccolumn,
+                                   fiberassign_dir=fiberassign_dir)
 
     # Can have the same targetid across different surveys and even within a
     # survey, across different tiles. So we need these columns.
@@ -373,9 +374,11 @@ def main():
             parent_zcat = Table(fitsio.read(parent_zcatfile))
 
             if rand is not None:
-                #parent_zcat = parent_zcat[parent_zcat['TILEID'] == 81108]
-                J = rand.choice(len(parent_zcat), size=args.ntest, replace=False)
-                parent_zcat = parent_zcat[J]
+                if False:
+                    parent_zcat = parent_zcat[parent_zcat['TILEID'] == 81108] # 80736
+                else:
+                    J = rand.choice(len(parent_zcat), size=args.ntest, replace=False)
+                    parent_zcat = parent_zcat[J]
             log.info('Read {:,} objects from {}'.format(len(parent_zcat), parent_zcatfile))
                 
             #print('RESTRICTING TO SURVEY sv2!')
@@ -435,6 +438,9 @@ def main():
                 log.info('Keeping {}/{} objects after removing sky targets and stuck positioners'.format(
                     np.sum(keep), len(zcat)))
                 zcat = zcat[keep]
+
+            #if True:
+            #    zcat = zcat[zcat['TILEID'] == 81108] # 80736
 
             log.info('Read {:,} objects from {} redshift catalogs'.format(len(zcat), len(zcatfiles)))
             
@@ -576,10 +582,7 @@ def main():
                 
             allzcat = vstack(allzcat, metadata_conflicts='silent')
 
-            try:
-                assert(np.all(allout['TARGETID'] == allzcat['TARGETID']))
-            except:
-                pdb.set_trace()
+            assert(np.all(allout['TARGETID'] == allzcat['TARGETID']))
                 
             allzcat.meta.pop('SURVEY')
             log.info('Writing {:,} objects to {}'.format(len(allzcat), outfile_zcat))
@@ -859,7 +862,8 @@ def main():
     if args.validate_targetphot:
         allout = []
 
-        zcatfiles = glob(os.path.join(args.reduxdir, 'zcatalog', 'ztile-*-cumulative.fits'))
+        zcatfiles = np.array(glob(os.path.join(args.reduxdir, 'zcatalog', 'ztile-*-cumulative.fits')))
+        #zcatfiles = np.array(glob(os.path.join(args.reduxdir, 'zcatalog', 'ztile-sv3*-cumulative.fits')))
         #zcatfiles = np.array(glob(os.path.join(args.reduxdir, 'zcatalog', 'ztile-sv1-other-cumulative.fits')))
         allsurveys = np.array([os.path.basename(zcatfile).split('-')[1] for zcatfile in zcatfiles])
 
@@ -872,37 +876,52 @@ def main():
 
             S = np.where(survey == allsurveys)[0]
             for zcatfile in zcatfiles[S]:
-                zcat = Table(fitsio.read(zcatfile))
-                log.info('Validating {:,} targets in {}'.format(len(zcat), zcatfile))
+                zcat_survey = Table(fitsio.read(zcatfile))
+                log.info('Validating {:,} targets in {}'.format(len(zcat_survey), zcatfile))
 
                 hdr = fitsio.read_header(zcatfile, ext=1)
-                zcat['SURVEY'] = hdr['SURVEY']
-                zcat['PROGRAM'] = hdr['PROGRAM']
+                zcat_survey['SURVEY'] = hdr['SURVEY']
+                zcat_survey['PROGRAM'] = hdr['PROGRAM']
     
                 # Toss out skies and stuck positioners.
-                _, _, _, _, sky, _ = decode_targetid(zcat['TARGETID'])
-                keep = (sky == 0) * (zcat['TARGETID'] > 0)    
-                zcat = zcat[keep]
+                _, _, _, _, sky, _ = decode_targetid(zcat_survey['TARGETID'])
+                keep = (sky == 0) * (zcat_survey['TARGETID'] > 0)    
+                zcat_survey = zcat_survey[keep]
 
-                _, uindx = np.unique(zcat['TARGETID'], return_index=True)
-                zcat = zcat[uindx]
-                zcat = zcat[np.argsort(zcat['TARGETID'])]
+                # Do not select unique TARGETIDs!
+                # See https://github.com/moustakas/desi-photometry/issues/3
+                
+                #_, uindx = np.unique(zcat_survey['TARGETID'], return_index=True)
+                #zcat_survey = zcat_survey[uindx]
+                #zcat_survey = zcat_survey[np.argsort(zcat_survey['TARGETID'])]
 
-                #I = np.isin(cat['TARGETID'], zcat['TARGETID'])
-                I = np.hstack([np.where(tid == cat['TARGETID'])[0] for tid in zcat['TARGETID']])
-                surveycat = cat[I]
-                assert(np.all(surveycat['TARGETID'] == zcat['TARGETID']))            
-    
-                ii = np.logical_not(np.isclose(zcat['FLUX_R'], surveycat['FLUX_R'], rtol=1e-3))
-                log.info('  Found {:,} mismatches.'.format(np.sum(ii)))
-                if np.sum(ii) > 0:
-                    out = join(zcat['SURVEY', 'PROGRAM', 'TILEID', 'TARGETID', 'FLUX_G', 'FLUX_R', 'FLUX_Z'][ii],
-                               surveycat['TARGETID', 'FLUX_G', 'FLUX_R', 'FLUX_Z'][ii], keys='TARGETID')
-                    allout.append(out)
+                # targets can repeat across tiles with different targeting information, so loop
+                mismatches = 0
+                for tileid in np.unique(zcat_survey['TILEID']):
+                    zcat_survey_onetile = zcat_survey[tileid == zcat_survey['TILEID']]
+
+                    surveycat = cat[cat['TILEID'] == tileid]
+                    
+                    #surveycat = surveycat[np.isin(surveycat['TARGETID'], zcat_survey_onetile['TARGETID'])]
+                    I = np.hstack([np.where(tid == surveycat['TARGETID'])[0] for tid in zcat_survey_onetile['TARGETID']])
+                    #surveycat = cat[I]                    
+                    surveycat = surveycat[I]
+                    assert(np.all(surveycat['TARGETID'] == zcat_survey_onetile['TARGETID']))
+
+                    ii = np.logical_not(np.isclose(zcat_survey_onetile['FLUX_R'], surveycat['FLUX_R'], rtol=1e-3))
+                    if np.sum(ii) > 0:
+                        mismatches += np.sum(ii)
+                        out = join(zcat_survey_onetile['SURVEY', 'PROGRAM', 'TILEID', 'TARGETID', 'FLUX_G', 'FLUX_R', 'FLUX_Z'][ii],
+                                   surveycat['TARGETID', 'FLUX_G', 'FLUX_R', 'FLUX_Z'][ii], keys='TARGETID',
+                                   table_names=['ZCAT', 'VAC'])
+                        allout.append(out)
+                    
+                log.info('  Found {:,} mismatches on survey {}.'.format(mismatches, survey))
     
         if len(allout) > 0:
             allout = vstack(allout)
             outfile = os.path.join(args.outdir, 'ancillary', 'targetphot-validate-{}.fits'.format(args.specprod))
+            print('Writing {} objects to {}'.format(len(allout), outfile))
             allout.write(outfile, overwrite=True)
 
 if __name__ == '__main__':

--- a/lsdr9-photometry
+++ b/lsdr9-photometry
@@ -4,14 +4,15 @@
 (target) catalogs.
 
 Set up the software dependencies but make sure we're using the desispec/0.53.2 tag, which is not yet part of a major release:
-  source /global/common/software/desi/desi_environment.sh 22.2
+  salloc -N 1 -C cpu -A desi -t 04:00:00 --qos interactive -L SCRATCH,cfs
+  source /global/common/software/desi/desi_environment.sh 22.5
   module unload desispec
   export PYTHONPATH=$HOME/code/desihub/desispec/py:${PYTHONPATH}
 
 Sequence of commands for a given release (here, fuji)
 1. Gather targeting photometry from the individual redshift catalogs.
 
-   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /global/cscratch1/sd/ioannis/photocatalog/fuji --specprod fuji --mp 32 --targetphot
+   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /pscratch/sd/i/ioannis/photocatalog/fuji --specprod fuji --mp 128 --targetphot
 
    Output files:
     targetphot-fuji.fits
@@ -20,15 +21,15 @@ Sequence of commands for a given release (here, fuji)
 
 2. Gather Tractor photometry.
 
-   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /global/cscratch1/sd/ioannis/photocatalog/fuji --specprod fuji --mp 32 --tractorphot
+   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /pscratch/sd/i/ioannis/photocatalog/fuji --specprod fuji --mp 128 --tractorphot
 
    Output files:
      tractorphot-nside4-hp???-fuji.fits
 
 3. Gather targeting and Tractor photometry for *potential* targets (going back to the original fiberassign files).
 
-   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /global/cscratch1/sd/ioannis/photocatalog/fuji --specprod fuji --mp 32 --targetphot --potential
-   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /global/cscratch1/sd/ioannis/photocatalog/fuji --specprod fuji --mp 32 --tractorphot --potential
+   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /pscratch/sd/i/ioannis/photocatalog/fuji --specprod fuji --mp 128 --targetphot --potential
+   time /global/homes/i/ioannis/code/desihub/desi-photometry/lsdr9-photometry --reduxdir $DESI_ROOT/spectro/redux/fuji -o /pscratch/sd/i/ioannis/photocatalog/fuji --specprod fuji --mp 128 --tractorphot --potential
 
    Output files:
      targetphot-potential-fuji.fits

--- a/validate-files
+++ b/validate-files
@@ -59,10 +59,15 @@ def fileinfo(filelist, specprod, subdir):
 
     nrows, szs = [], []
     for onefile in filelist:
-        szs.append(os.stat(onefile).st_size)
-        nrows.append(fitsio.FITS(onefile)[1].get_nrows())
+        if os.path.isfile(onefile):
+            szs.append(os.stat(onefile).st_size)
+            nrows.append(fitsio.FITS(onefile)[1].get_nrows())
+        else:
+            print('Missing {}'.format(onefile))
     szs = np.array(szs)
     nrows = np.array(nrows)
+    if len(nrows) == 0:
+        return
 
     #srt = np.argsort(nrows)
     srt = np.arange(len(nrows))
@@ -154,6 +159,9 @@ def main():
             print('Working on survey {}'.format(survey))
             obsfile = os.path.join(args.outdir, 'observed-targets', 'targetphot-{}-{}.fits'.format(survey, args.specprod))
             potfile = os.path.join(args.outdir, 'potential-targets', 'targetphot-potential-{}-{}.fits'.format(survey, args.specprod))
+            #if not os.path.isfile(obsfile):
+            #    continue
+            
             obs = Table(fitsio.read(obsfile))
             print('Read {:,d} objects from {}'.format(len(obs), obsfile))
             pot = Table(fitsio.read(potfile))


### PR DESCRIPTION
This version inherits all the fixes from patching the early fiberassign files plus a couple critical bugs in how the targeting catalogs were being gathered which were identified in the v1.0 version of the catalogs (fixed in https://github.com/desihub/desispec/pull/1971 and https://github.com/desihub/desispec/commit/458eb06a177d860d4e21c424e7cfc84a8cd47bb2.

Results are being staged for review in--
```
/pscratch/sd/i/ioannis/photocatalog/fuji
/pscratch/sd/i/ioannis/photocatalog/guadalupe
```
